### PR TITLE
fix emoji chars and insert by batch

### DIFF
--- a/target_mysql/streams.py
+++ b/target_mysql/streams.py
@@ -167,8 +167,8 @@ class MSSQLStream(Stream):
             logging.error(f"Caught exception whie running sql: {sql}")
             raise e
 
-    def sql_runner_withparams(self, sql, paramaters):         
-        self.batch_cache.append(paramaters)
+    def sql_runner_withparams(self, sql, parameters):         
+        self.batch_cache.append(parameters)
         if(len(self.batch_cache)>=self.batch_size):
             logging.info(f"Running batch with SQL: {sql} . Batch size: {len(self.batch_cache)}")
             self.commit_batched_data(sql, self.batch_cache)

--- a/target_mysql/streams.py
+++ b/target_mysql/streams.py
@@ -25,7 +25,6 @@ class MSSQLStream(Stream):
         self.cursor = self.conn.cursor()
         self.dml_sql = None
         self.properties_dict = {}
-        self.number_cols = 0
         self.batch_cache = []
         self.batch_size = 1000 if batch_size is None else batch_size
         self.full_table_name = self.generate_full_table_name(self.name, schema_name)

--- a/target_mysql/streams.py
+++ b/target_mysql/streams.py
@@ -174,23 +174,6 @@ class MSSQLStream(Stream):
             self.commit_batched_data(sql, self.batch_cache)
             self.batch_cache = [] #Get our cache ready for more!
   
-    #Commits a single record
-    def commit_data(self,dml,values):
-        try:
-            self.conn.autocommit = False
-            logging.info("Commiting a single record")
-            self.cursor.execute(dml,values)
-        except pyodbc.DatabaseError as e:
-            logging.error(f"Caught exception while running batch sql: {dml}. Parameters for sql: {values} ")
-            self.conn.rollback()
-            raise e
-        else:
-            self.conn.commit()
-            logging.info(f"Record with {dml} and {values} successfully committed")
-        finally:
-    
-            self.conn.autocommit = True #Set us back to the default of autoCommiting for other actions
-       
     def commit_batched_data(self, dml, cache):
         try:
             self.conn.autocommit = False

--- a/target_mysql/target.py
+++ b/target_mysql/target.py
@@ -34,6 +34,7 @@ class TargetMSSQL(Target):
                                         database=self.config.get("database"),
                                         )
         self.conn.setdecoding(pyodbc.SQL_WCHAR, encoding='utf-8')
+        self.conn.setdecoding(pyodbc.SQL_WMETADATA, encoding='utf-16le')
         self.conn.setencoding(encoding='utf-8', ctype=pyodbc.SQL_CHAR)
         self.conn.setencoding(encoding='utf-8')
 
@@ -53,4 +54,4 @@ cli = TargetMSSQL.cli()
 
 
 if __name__ == "__main__":
-    cli
+    cli()


### PR DESCRIPTION
### Description of change
- Add Emoji characters support
-  Fix insert by batch (hardcoded to 1000 records)
### Disadvantages
Inserting by batch depends on each record having the same number of columns, to accomplish that:
- The first record after the schema declaration is taken as a reference to set the number of columns. So if the next record has the same number is processed in the batch.
- If the record has fewer columns it's inserted individually.
### Rollback steps
 - revert this branch
### Task
[Linear Task](https://linear.app/hotglue/issue/HGI-2158/[leasecake]-failed-export-to-target-mysql)
